### PR TITLE
Fix undo logic to prevent empty stack access

### DIFF
--- a/design-patterns/src/main/java/org/prateek/BehaviouralPatterns/MementoPattern/Caretaker.java
+++ b/design-patterns/src/main/java/org/prateek/BehaviouralPatterns/MementoPattern/Caretaker.java
@@ -10,7 +10,7 @@ public class Caretaker {
         history.push(editor.save());
     }
     public void undo(TextEditor editor){
-        if(!history.empty()){
+        if(history.size()>1){
           history.pop();
           editor.restore(history.peek());
         }


### PR DESCRIPTION
## Description
This PR fixes an issue in the `undo()` method of the `Caretaker` class.

Previously, the condition `!history.empty()` allowed `undo()` to execute even when only one state was present. After `pop()`, this could result in calling `peek()` on an empty stack, leading to a runtime exception.

## Changes
- Updated condition from `!history.empty()` to `history.size() > 1`
- Ensures a previous state exists before performing `undo()`
- Prevents invalid stack access (`peek()` on empty stack)

## Why
The `undo()` operation should only run when there is a valid previous state to restore. This change improves safety and prevents edge-case failures.

